### PR TITLE
Get bluetooth working

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -240,3 +240,4 @@ persist.data.qmi.adb_logmask=0
 
 #Bluetooth
 ro.qualcomm.bt.hci_transport=smd
+qcom.bluetooth.soc=smd


### PR DESCRIPTION
Workaraound to get bluetooth working again. Not sure if the other two lines related to BT in build.prop are needed.