### PR TITLE
sensor: light: current value is 100x lower than what it should be.

### DIFF
--- a/sensors/LightSensor.cpp
+++ b/sensors/LightSensor.cpp
@@ -308,5 +308,5 @@ float LightSensor::convertEvent(int value)
 		}
 	}
 	// There seems to be a factor 10 in the returned lux value.
-	return lux / 10.0f;
+	return lux * 10.0f;
 }


### PR DESCRIPTION
Sensor was returning a very low lux value (About 5~20 lux), and so, auto brightness didn't work properly.

The max possible value (75) was lower then the third brightness stage: https://github.com/boulzordev/android_device_lenovo_A6020/blob/cm-14.1/overlay/frameworks/base/core/res/res/values/config.xml#L43

Now, the max value is 7500 as it should.

Check: https://github.com/boulzordev/android_device_lenovo_A6020/commit/3a2e727493789789fb0431563e1dee046cbc1bb8