### PR TITLE
A6020: fix atomic call for camera

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -46,7 +46,7 @@ on init
     # Set permissions for persist partition
     mkdir /persist 0771 system system
 
-    export LD_SHIM_LIBS /system/lib64/libril.so|libshim_ril.so:/system/vendor/lib/libmmcamera2_stats_modules.so|libshim_gui.so:/system/vendor/lib/libmmqjpeg_codec.so|libboringssl-compat.so
+    export LD_SHIM_LIBS /system/lib64/libril.so|libshim_ril.so:/system/vendor/lib/libmmcamera2_stats_modules.so|libshim_gui.so:/system/vendor/lib/libmmqjpeg_codec.so|libboringssl-compat.so:/system/vendor/lib/libmmcamera2_stats_algorithm.so|libshim_atomic.so
 
     # Enable power-on alarm
     write /sys/module/qpnp_rtc/parameters/poweron_alarm 1


### PR DESCRIPTION
*this still pops up in our logs , hoping this commit would fix the issue
libc : CANNOT LINK EXECUTABLE "/system/bin/mm-qcamera-daemon": cannot locate symbol "android_atomic_acquire_load" referenced by "/system/vendor/lib/libmmcamera2_stats_modules.so"..